### PR TITLE
instanceData buffer resize buffer bug fix

### DIFF
--- a/cocos2d/core/renderer/webgl/instance-buffer.js
+++ b/cocos2d/core/renderer/webgl/instance-buffer.js
@@ -14,7 +14,8 @@ let instanceTexture = null;
 let instanceDataTexOptions = null;
 
 let SUPPORT_FLOAT_TEXTURE = false;
-let size = 64;
+let size = 64; //Texture Size, Must be an integer multiple of 4
+let FixedRequestCount = size * size / 4;
 
 let fixLength = 0;
 let freeIndexBuffer = [];
@@ -26,7 +27,7 @@ function checkFloatSupport () {
 export function initFreeIndexBuffer () {
     if (fixLength === 0) {
         checkFloatSupport();
-        freeIndexBuffer.length = fixLength = SUPPORT_FLOAT_TEXTURE ? size * size / 4 : size * size / 16;
+        freeIndexBuffer.length = fixLength = size * size / 4;
         for(let i = 0; i < freeIndexBuffer.length; i++ ) {
             freeIndexBuffer[i] = i;
         }
@@ -38,7 +39,7 @@ export function initFreeIndexBuffer () {
 
 function resizeDataBuffer () {
     size *= 2;
-    freeIndexBuffer.length = (SUPPORT_FLOAT_TEXTURE ? size * size / 4 : size * size / 16) - fixLength;
+    freeIndexBuffer.length = size * size / 4 - fixLength;
     for(let i = 0; i < freeIndexBuffer.length; i++ ) {
         freeIndexBuffer[i] = i + fixLength;
     }
@@ -136,8 +137,6 @@ export function getResizeDirty () {
 export function setResizeDirty (value) {
     resizeDirty = value;
 }
-
-let FixedRequestCount = 2000;
 
 export function getBuffer () {
     if (!instanceBuffer) {

--- a/cocos2d/renderer/gfx/device.js
+++ b/cocos2d/renderer/gfx/device.js
@@ -455,7 +455,8 @@ let posLocation = -1
 function bindInstance (gl, program) {
 
   if (posLocation === -1) {
-    posLocation = program._attributes.findIndex(a => a.name === 'a_position')
+    // posLocation = program._attributes.findIndex(a => a.name === 'a_position')
+    posLocation = program._attributes.findIndex(a => a.name === cc.gfx.ATTR_POSITION)
   }
 
   if (!quadVB) {


### PR DESCRIPTION
- 调整了 FixedRequestCount 的初始值，这个值其实够用情况下越小越好，可减小传递消耗，所以最好有个自动缩小的机制
- FixedRequestCount 的值（即instancebuffer的长度）为何不与 texture 所能容纳的最多值统一，因为没必要，texture 同样也是够用情况越小越好，但 texture 的边长需要为 16 的倍数（RGBA8情况下），instancebuffer 则无此要求，所以没必要强行绑定，texture的大小是最多能容纳的数量，instancebuffer 则不需要那么大。当然，texture 最好也具备自动缩小功能。
- 要说 size 和 FixedRequestCount 的关系，也就只有 FixedRequestCount 不能大于 size * size / 4 这一点了
- 注意，多张 dataTexture 的机制尚未添加，一般情况下不会产生问题
- 如果不进行 floatTexture 直接影响 texture 的宽，是能够在一张图上填更多数据的，但是会导致在计算数据块数量的时候，都需要进行不同模式的处理